### PR TITLE
Fix hvm1 and hvm2 links to accomodate repo renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 *Note: The latest version of Bend targets an unreleased version of HVM. If you want to use Bend right now, use branch [hvm-core](https://github.com/HigherOrderCO/bend/tree/hvm-core)*.
 
-Bend is a programming language that can run massively parallel programs on the GPU or the CPU using the power of interaction nets and the [HVM](https://github.com/HigherOrderCO/hvm2).
+Bend is a programming language that can run massively parallel programs on the GPU or the CPU using the power of interaction nets and the [HVM](https://github.com/HigherOrderCO/hvm).
 With Bend, you can write programs for the GPU as easily as you'd write a normal program in your favorite language.
 
 It is based on the [Interaction-Calculus](https://github.com/VictorTaelin/Interaction-Calculus#interaction-calculus), a variation of the untyped lambda calculus that compiles efficiently to interaction nets.
 
-Currently Bend only supports strict/eager evaluation. If you need lazy, optimal evaluation, we recommend using [HVM1](https://github.com/HigherOrderCO/HVM) for now.
+Currently Bend only supports strict/eager evaluation. If you need lazy, optimal evaluation, we recommend using [HVM1](https://github.com/HigherOrderCO/HVM1) for now.
 
 
 ## Installation


### PR DESCRIPTION
HVM2 has been renamed HVM and HVM has been renamed HVM1. Fixed 2 places in the README.md to fix that.