### PR TITLE
Fix shader usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ def render(depth, shader):
       color = (fork(d+1, i*2+0), fork(d+1, i*2+1))
     else:
       width = depth / 2
-      color = demo_shader(i % width, i / width)
+      color = shader(i % width, i / width)
   return color
 
 # given a position, returns a color


### PR DESCRIPTION
I think there is a mistake in one of the examples in readme, `shader` argument is not actually used.