### PR TITLE
Changed return type of fn main() in src/main.rs to fn main() -> std::process::ExitCode.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,10 @@ use bend::{
   load_file_to_book, run_book_with_fn, CompileOpts, OptLevel, RunOpts,
 };
 use clap::{Args, CommandFactory, Parser, Subcommand};
-use std::path::{Path, PathBuf};
-use std::process::ExitCode;
+use std::{
+  path::{Path, PathBuf},
+  process::ExitCode,
+};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use bend::{
 };
 use clap::{Args, CommandFactory, Parser, Subcommand};
 use std::path::{Path, PathBuf};
+use std::process::ExitCode;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -222,15 +223,18 @@ pub enum WarningArgs {
   RecursionCycle,
 }
 
-fn main() {
+fn main() -> ExitCode {
   #[cfg(not(feature = "cli"))]
   compile_error!("The 'cli' feature is needed for the hvm-lang cli");
 
   let cli = Cli::parse();
 
   if let Err(diagnostics) = execute_cli_mode(cli) {
-    eprint!("{diagnostics}")
+    eprint!("{diagnostics}");
+    return ExitCode::FAILURE;
   }
+
+  ExitCode::SUCCESS
 }
 
 fn execute_cli_mode(mut cli: Cli) -> Result<(), Diagnostics> {


### PR DESCRIPTION
Hi, I did this because I needed it for personal use. Since the "bend check [file]" command returned 0 in $?, even if it failed or reported an error. So in order to being able to check the exit status of "bend check" I added a return ExitCode::FAILURE, when execute_cli_mode(cli) returned a diagnostics message to main().