### PR TITLE
Add missing recursive marker in List definition.

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -172,7 +172,7 @@ datatypes on Bend. Specifically, the type:
 ```python
 type List:
   Nil
-  Cons { head, tail }
+  Cons { head, ~tail }
 ```
 
 Here, the `Nil` variant represents an empty list, and the `Cons` variant


### PR DESCRIPTION
In **GUIDE.md**, the definition of `List` is given but it is missing the recursive `~` marker on the `tail`.
This PR adds it where it should be.