### PR TITLE
docs: fix accidental replacement

### DIFF
--- a/docs/compiler-options.md
+++ b/docs/compiler-options.md
@@ -16,7 +16,7 @@
 
 Enables or disables Eta Reduction for defined functions.
 
-Eta reduction simplifies lambda expressions, removing redundant parameters. [See also](https:#wiki.haskell.org/Eta_conversion).
+Eta reduction simplifies lambda expressions, removing redundant parameters. [See also](https://wiki.haskell.org/Eta_conversion).
 
 Example:
 ```py


### PR DESCRIPTION
Fixes an invalid link introduced with replacement (I guess) in #386 ([exact change](https://github.com/HigherOrderCO/Bend/pull/386/files#diff-2fb18301a62221a0b9f8febe8f83e0a4a6c8b2177493a5d4fbfa50fc139d42acL18-R19))
