### PR TITLE
Standardize Changelog Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,90 @@
 # Changelog
 
-## 0.2.35
-- Changed lambda `Term` with bind patterns to display as `let` terms.
+All notable changes to this project will be documented in this file.
 
-## 0.2.34
-- Added `<=` and `>=` operators. (#451)
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project does not adhere to a particular versioning scheme at this point.
 
-## 0.2.33
-- Added `expand_main`, a compilation pass that expands references in the entry point function. (#424)
-- Changed the `float_combinators` pass to not extract in the entry point function. (#424)
+## [0.2.35] - 2024-06-06
 
-## 0.2.32
-- Added the built-in `Tree` datatype. (#528)
-- Added `![]` and `!` syntax for `Tree` literals. (#528)
-- Moved the builtins documentation to `/docs`.
-- Created the changelog.
+### Changed
 
-## 0.2.0
+- Make lambda `Term` with bind patterns display as `let` terms. ([#466][gh-466])
+
+## [0.2.34] - 2024-06-05
+
+### Added
+
+- Create `<=` and `>=` operators. ([#451][gh-451])
+
+## [0.2.33] - 2024-06-05
+
+### Added
+
+- Implement `expand_main`, a compilation pass that expands references in the entry point function. ([#424][gh-424])
+
+### Changed
+
+- Make the `float_combinators` pass no longer extract in the entry point function. ([#424][gh-424])
+
+## [0.2.32] - 2024-06-05
+
+### Added
+
+- Implement the built-in `Tree` datatype. ([#528][gh-528])
+- Implement `![]` and `!` syntax for `Tree` literals. ([#528][gh-528])
+- Create a changelog.
+
+### Changed
+
+- Move the builtins documentation to `/docs`.
+
+## [0.2.30] - 2024-06-04
+
+### Changed
+
+- No longer expand generated recursive definitions. ([#502][gh-502])
+
+## [0.2.29] - 2024-06-04
+
+### Added
+
+- Support custom HVM binaries. ([#479][gh-479])
+
+### Changed
+
+- Make monadic blocks lazy by deferring execution of continuations with free vars. ([#526][gh-526])
+
+## [0.2.28] - 2024-05-30
+
+### Added
+
+- Support mapper statements. ([#465][gh-465])
+
+## [0.2.27] - 2024-05-29
+
+### Changed
+
+- Make `with` clauses take a bind and an argument
+
+## [0.2.0] - 2024-05-14
+
 - Initial public release of Bend.
+
+[0.2.0]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.0
+[0.2.27]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.27
+[0.2.28]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.28
+[0.2.29]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.29
+[0.2.30]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.30
+[0.2.32]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.32
+[0.2.33]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.33
+[0.2.34]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.34
+[0.2.35]: https://github.com/HigherOrderCO/Bend/releases/tag/0.2.35
+[gh-424]: https://github.com/HigherOrderCO/Bend/issues/424
+[gh-451]: https://github.com/HigherOrderCO/Bend/issues/451
+[gh-465]: https://github.com/HigherOrderCO/Bend/issues/465
+[gh-466]: https://github.com/HigherOrderCO/Bend/issues/466
+[gh-479]: https://github.com/HigherOrderCO/Bend/issues/479
+[gh-502]: https://github.com/HigherOrderCO/Bend/issues/502
+[gh-526]: https://github.com/HigherOrderCO/Bend/issues/526
+[gh-528]: https://github.com/HigherOrderCO/Bend/issues/528


### PR DESCRIPTION
Clean up the changelog format to obey the dictates of the [KeepAChangelog spec](https://keepachangelog.com/en/1.1.0/).
I think that this should be relatively uncontroversial, but I did have a few thoughts.

I didn't add in an "unreleased" section, as I wasn't sure if y'all want to get into the habit of writing changelogs alongside changes. If so, I can add it in.
Secondly, the changelog header now says that this follows SemVer. While SemVer pre-1.0 says that you can do anything you want breaking-changes-wise, it does imply that you intend in following SemVer post-1.0. Is that accurate?
Thirdly, there aren't tags for many recent releases. I linked them anyway, figuring that they could be backfilled.

Even if you decide not to conform to KeepAChangelog, I'd still recommend linking releases and issues, and noting the dates. Linking the context makes them a lot more useful.

I'm also starting to backfill the entries locally.

_**Relates to:** #549_
