### PR TITLE
#564 Add notes on square brackets syntax

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -374,6 +374,7 @@ type Map:
 ```
 
 Notice that the getter and setter syntax induces an order on things using the map, since every get or set operation depends on the value of the previous map.
+> **_NOTE:_** Do not get mistaken with lists creation syntax, that also uses `[` `]`.
 
 ### Mixing syntaxes
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -234,6 +234,7 @@ def main:
 ```
 
 Will return `1`, which is the first element.
+> **_NOTE:_** Despite creating lists with `[` `]`, the syntax used for accessing values as in `type[key]` is actually related to the `Map` built-in type.
 
 We also have a syntax sugar for strings in Bend, which is just a list of `u24`
 characters (UTF-16 encoded). The `"Hello, world!"` type we've seen used it!


### PR DESCRIPTION
Addition of notes to improve clarity on GUIDE.md and FEATURES.md regarding the square brackets syntax difference of lists and maps on Bend.

Fix #564.