### PR TITLE
add hvm benchmark && recode inline_hvm_book  && hvm_book_show_pretty

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ lto = true
 [features]
 default = ["cli"]
 cli = ["dep:clap"]
+bench = []
+
 
 [dependencies]
 TSPL = "0.0.13"
@@ -41,3 +43,7 @@ walkdir = "2.3.3"
 
 [profile.test]
 opt-level = 2
+
+[[bench]]
+name = "hvm_common"
+harness = true

--- a/benches/hvm_common.rs
+++ b/benches/hvm_common.rs
@@ -1,0 +1,92 @@
+use hvm::ast::{Book, Net, Tree};
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct SimpleRng(u64);
+
+impl SimpleRng {
+  pub fn new() -> Self {
+    SimpleRng(SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs())
+  }
+
+  pub fn gen_range(&mut self, low: u64, high: u64) -> u64 {
+    self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+    low + (self.0 >> 32) % (high - low)
+  }
+}
+
+impl Default for SimpleRng {
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+// Fuzzing testing by create tree
+pub fn create_random_tree(rng: &mut SimpleRng, depth: u32, var_prefix: &str) -> Tree {
+  if depth == 0 || rng.gen_range(0, 100) < 30 {
+    // 30% chance to generate a Var or Era
+    if rng.gen_range(0, 100) < 50 {
+      Tree::Var { nam: format!("{}_{}", var_prefix, rng.gen_range(0, 10)) }
+    } else {
+      Tree::Era
+    }
+  } else {
+    // 70% chance to generate a Con or Dup
+    let is_con = rng.gen_range(0, 100) < 50;
+    let fst = Box::new(create_random_tree(rng, depth - 1, var_prefix));
+    let snd = Box::new(create_random_tree(rng, depth - 1, var_prefix));
+
+    if is_con {
+      Tree::Con { fst, snd }
+    } else {
+      Tree::Dup { fst, snd }
+    }
+  }
+}
+// Fuzzing testing by create book
+#[allow(dead_code)]
+pub fn create_test_book(rng: &mut SimpleRng, num_defs: usize, max_depth: u32, max_rbag: usize) -> Book {
+  let mut defs = BTreeMap::new();
+  for i in 0..num_defs {
+    let name = format!("Def_{}", i);
+    let depth = (rng.gen_range(1, max_depth as u64 + 1)) as u32;
+    let root = create_random_tree(rng, depth, "root");
+    let rbag_size = rng.gen_range(0, max_rbag as u64 + 1) as usize;
+    let rbag = (0..rbag_size)
+      .map(|_| {
+        (
+          false,
+          create_random_tree(rng, 20, &format!("left_{}", i)),
+          create_random_tree(rng, 20, &format!("right_{}", i)),
+        )
+      })
+      .collect();
+    defs.insert(name, Net { root, rbag });
+  }
+  for i in 0..num_defs / 10 {
+    let name = format!("Inline_{}", i);
+    let root = Tree::Ref { nam: format!("Ref_{}", rng.gen_range(0, num_defs as u64)) };
+    defs.insert(name, Net { root, rbag: vec![] });
+  }
+  Book { defs }
+}
+// Fuzzing testing by create net
+#[allow(dead_code)]
+pub fn books_cases() -> Book {
+  let mut rng = SimpleRng::new();
+  create_test_book(&mut rng, 100, 5, 3)
+}
+
+// Fuzzing testing by create net
+#[allow(dead_code)]
+pub fn create_test_net(rng: &mut SimpleRng, max_refs: u32, size: u32) -> Net {
+  let root = create_random_tree(rng, max_refs, "root");
+  let mut rbag = Vec::new();
+  for i in 0..size {
+    let left = create_random_tree(rng, size, &format!("left_{}", i));
+    let right = create_random_tree(rng, size, &format!("right_{}", i));
+    rbag.push((false, left, right));
+  }
+
+  Net { root, rbag }
+}

--- a/benches/hvm_eta_reduce_benchmarks.rs
+++ b/benches/hvm_eta_reduce_benchmarks.rs
@@ -1,0 +1,15 @@
+#![feature(test)]
+
+extern crate test;
+mod hvm_common;
+
+use bend::hvm::eta_reduce::eta_reduce_hvm_net;
+use hvm_common::{create_test_net, SimpleRng};
+use test::Bencher;
+
+#[bench]
+fn bench_eta_reduce_small(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let net = create_test_net(&mut rng, 5, 3);
+  b.iter(|| eta_reduce_hvm_net(&mut net.clone()));
+}

--- a/benches/hvm_inline_benchmarks.rs
+++ b/benches/hvm_inline_benchmarks.rs
@@ -1,0 +1,29 @@
+#![feature(test)]
+
+extern crate test;
+mod hvm_common;
+
+use bend::hvm::inline::inline_hvm_book;
+use hvm_common::{create_test_book, SimpleRng};
+use test::Bencher;
+
+#[bench]
+fn bench_fuzzing_inline_small(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let mut test_book = create_test_book(&mut rng, 50, 5, 10);
+  b.iter(|| inline_hvm_book(&mut test_book));
+}
+
+#[bench]
+fn bench_fuzzing_inline_medium(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let mut test_book = create_test_book(&mut rng, 100, 10, 10);
+  b.iter(|| inline_hvm_book(&mut test_book));
+}
+
+#[bench]
+fn bench_fuzzing_inline_large(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let mut test_book = create_test_book(&mut rng, 500, 15, 10);
+  b.iter(|| inline_hvm_book(&mut test_book));
+}

--- a/benches/hvm_mutual_recursion_bench.rs
+++ b/benches/hvm_mutual_recursion_bench.rs
@@ -1,0 +1,22 @@
+#![feature(test)]
+
+extern crate test;
+mod hvm_common;
+
+use bend::diagnostics::Diagnostics;
+use bend::diagnostics::DiagnosticsConfig;
+use bend::hvm::mutual_recursion::check_cycles;
+use hvm_common::{create_test_book, SimpleRng};
+
+use test::Bencher;
+
+#[bench]
+fn bench_check_cycles(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let book = create_test_book(&mut rng, 500, 10, 50);
+  b.iter(|| {
+    let config = DiagnosticsConfig::default();
+    let mut diagnostics = Diagnostics::new(config);
+    check_cycles(&book, &mut diagnostics)
+  });
+}

--- a/benches/hvm_net_size_benchmarks.rs
+++ b/benches/hvm_net_size_benchmarks.rs
@@ -1,0 +1,44 @@
+#![feature(test)]
+
+extern crate test;
+mod hvm_common;
+
+use bend::diagnostics::Diagnostics;
+use bend::hvm::check_net_size::{check_net_sizes, count_nodes};
+use bend::CompilerTarget;
+use hvm_common::{books_cases, create_test_net, SimpleRng};
+use test::Bencher;
+
+#[bench]
+fn bench_fuzzing_check_net_sizes_c(b: &mut Bencher) {
+  let book = books_cases();
+  b.iter(|| {
+    let mut diagnostics = Diagnostics::new(Default::default());
+    check_net_sizes(&book, &mut diagnostics, &CompilerTarget::C)
+  });
+}
+
+#[bench]
+fn bench_fuzzing_check_net_sizes_cuda(b: &mut Bencher) {
+  let book = books_cases();
+  b.iter(|| {
+    let mut diagnostics = Diagnostics::new(Default::default());
+    check_net_sizes(&book, &mut diagnostics, &CompilerTarget::Cuda)
+  });
+}
+
+#[bench]
+fn bench_fuzzing_count_nodes_small(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let net = create_test_net(&mut rng, 5, 15);
+
+  b.iter(|| count_nodes(&net));
+}
+
+#[bench]
+fn bench_fuzzing_count_nodes_large(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let net = create_test_net(&mut rng, 10, 15);
+
+  b.iter(|| count_nodes(&net));
+}

--- a/benches/hvm_prune_book_benchmark.rs
+++ b/benches/hvm_prune_book_benchmark.rs
@@ -1,0 +1,76 @@
+#![feature(test)]
+extern crate test;
+use bend::hvm::prune::prune_hvm_book;
+use hvm::ast::{Book, Net, Tree};
+use std::collections::BTreeMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+use test::Bencher;
+
+// Simple random number generator
+struct SimpleRng(u64);
+
+impl SimpleRng {
+  fn new() -> Self {
+    let seed = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs();
+    SimpleRng(seed)
+  }
+
+  fn gen_range(&mut self, low: u64, high: u64) -> u64 {
+    self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
+    low + (self.0 >> 32) % (high - low)
+  }
+}
+
+fn create_test_book(rng: &mut SimpleRng, num_defs: usize, max_depth: u32, max_rbag: usize) -> Book {
+  let mut defs = BTreeMap::new();
+  for i in 0..num_defs {
+    let name = format!("Def_{}", i);
+    let depth = (rng.gen_range(1, max_depth as u64 + 1)) as u32;
+    let root = create_random_tree(rng, depth, num_defs);
+    let rbag_size = rng.gen_range(0, max_rbag as u64 + 1) as usize;
+    let rbag = (0..rbag_size)
+      .map(|_| (false, create_random_tree(rng, 2, num_defs), create_random_tree(rng, 2, num_defs)))
+      .collect();
+    defs.insert(name, Net { root, rbag });
+  }
+
+  // Ensure some definitions are inlineable
+  for i in 0..num_defs / 10 {
+    let name = format!("Inline_{}", i);
+    let root = Tree::Ref { nam: format!("Ref_{}", rng.gen_range(0, num_defs as u64)) };
+    defs.insert(name, Net { root, rbag: vec![] });
+  }
+
+  Book { defs }
+}
+
+fn create_random_tree(rng: &mut SimpleRng, depth: u32, max_refs: usize) -> Tree {
+  if depth == 0 || rng.gen_range(0, 100) < 30 {
+    // 30% chance to generate a Ref or Era
+    if rng.gen_range(0, 100) < 50 {
+      Tree::Ref { nam: format!("Ref_{}", rng.gen_range(0, max_refs as u64)) }
+    } else {
+      Tree::Era
+    }
+  } else {
+    // 70% chance to generate a Con or Dup
+    let is_con = rng.gen_range(0, 100) < 50;
+    let fst = Box::new(create_random_tree(rng, depth - 1, max_refs));
+    let snd = Box::new(create_random_tree(rng, depth - 1, max_refs));
+    if is_con {
+      Tree::Con { fst, snd }
+    } else {
+      Tree::Dup { fst, snd }
+    }
+  }
+}
+
+#[bench]
+fn bench_prune_hvm_book(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let entrypoints = vec!["Def_0".to_string(), "Def_50".to_string()];
+  b.iter(|| {
+    let mut book = create_test_book(&mut rng, 50, 5, 10); // Book with 50 definitions
+    prune_hvm_book(&mut book, &entrypoints);
+  });
+}

--- a/benches/hvm_prune_book_benchmark.rs
+++ b/benches/hvm_prune_book_benchmark.rs
@@ -1,25 +1,12 @@
 #![feature(test)]
 extern crate test;
+mod hvm_common;
+
 use bend::hvm::prune::prune_hvm_book;
 use hvm::ast::{Book, Net, Tree};
+use hvm_common::SimpleRng;
 use std::collections::BTreeMap;
-use std::time::{SystemTime, UNIX_EPOCH};
 use test::Bencher;
-
-// Simple random number generator
-struct SimpleRng(u64);
-
-impl SimpleRng {
-  fn new() -> Self {
-    let seed = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_secs();
-    SimpleRng(seed)
-  }
-
-  fn gen_range(&mut self, low: u64, high: u64) -> u64 {
-    self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1);
-    low + (self.0 >> 32) % (high - low)
-  }
-}
 
 fn create_test_book(rng: &mut SimpleRng, num_defs: usize, max_depth: u32, max_rbag: usize) -> Book {
   let mut defs = BTreeMap::new();

--- a/benches/hvm_utils_benchmarks.rs
+++ b/benches/hvm_utils_benchmarks.rs
@@ -1,0 +1,94 @@
+#![feature(test)]
+
+extern crate test;
+
+mod hvm_common;
+use bend::hvm::{hvm_book_show_pretty, net_trees, net_trees_mut, tree_children, tree_children_mut};
+use hvm_common::{books_cases, create_random_tree, create_test_net, SimpleRng};
+use test::Bencher;
+
+#[bench]
+fn bench_fuzzing_tree_children(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let tree = create_random_tree(&mut rng, 10, "root");
+
+  b.iter(|| {
+    for child in tree_children(&tree) {
+      test::black_box(child);
+    }
+  });
+}
+
+#[bench]
+fn bench_fuzzing_tree_children_mut(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let mut tree = create_random_tree(&mut rng, 10, "root");
+
+  b.iter(|| {
+    for child in tree_children_mut(&mut tree) {
+      test::black_box(child);
+    }
+  });
+}
+
+#[bench]
+fn bench_fuzzing_net_trees(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let net = create_test_net(&mut rng, 5, 3);
+
+  b.iter(|| {
+    for tree in net_trees(&net) {
+      test::black_box(tree);
+    }
+  });
+}
+// original https://github.com/HigherOrderCO/Bend/blob/main/src/hvm/mod.rs#L39
+#[allow(dead_code)]
+fn original_hvm_book_show_pretty(book: &hvm::ast::Book) -> String {
+  let mut s = String::new();
+  for (nam, def) in book.defs.iter() {
+    s.push_str(&format!("@{} = {}\n", nam, def.root.show()));
+    for (pri, a, b) in def.rbag.iter() {
+      s.push_str("  &");
+      if *pri {
+        s.push('!');
+      } else {
+        s.push(' ');
+      }
+      s.push_str(&a.show());
+      s.push_str(" ~ ");
+      s.push_str(&b.show());
+      s.push('\n');
+    }
+    s.push('\n');
+  }
+  s
+}
+
+#[bench]
+fn bench_fuzzing_net_trees_mut(b: &mut Bencher) {
+  let mut rng = SimpleRng::new();
+  let mut net = create_test_net(&mut rng, 5, 3);
+
+  b.iter(|| {
+    for tree in net_trees_mut(&mut net) {
+      test::black_box(tree);
+    }
+  });
+}
+
+#[bench]
+fn bench_original(b: &mut Bencher) {
+  let book = books_cases();
+  b.iter(|| {
+    test::black_box(original_hvm_book_show_pretty(&book));
+  });
+}
+
+#[bench]
+fn bench_optimized(b: &mut Bencher) {
+  let book = books_cases();
+  b.iter(|| {
+    test::black_box(hvm_book_show_pretty(&book));
+  });
+}

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -388,7 +388,7 @@ impl Display for Diagnostic {
 }
 
 impl Diagnostic {
-  pub fn display_with_origin<'a>(&'a self, origin: &'a DiagnosticOrigin) -> impl std::fmt::Display + '_ {
+  pub fn display_with_origin<'a>(&'a self, origin: &'a DiagnosticOrigin) -> impl std::fmt::Display + 'a {
     DisplayFn(move |f| {
       match origin {
         DiagnosticOrigin::Parsing => writeln!(f, "{self}")?,

--- a/src/hvm/inline.rs
+++ b/src/hvm/inline.rs
@@ -2,70 +2,81 @@ use super::{net_trees_mut, tree_children, tree_children_mut};
 use crate::maybe_grow;
 use core::ops::BitOr;
 use hvm::ast::{Book, Net, Tree};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
+use std::mem;
 
 pub fn inline_hvm_book(book: &mut Book) -> Result<HashSet<String>, String> {
   let mut state = InlineState::default();
   state.populate_inlinees(book)?;
+
   let mut all_changed = HashSet::new();
-  for (name, net) in &mut book.defs {
+  let mut new_defs = BTreeMap::new();
+
+  for (name, mut net) in mem::take(&mut book.defs) {
     let mut inlined = false;
-    for tree in net_trees_mut(net) {
+    for tree in net_trees_mut(&mut net) {
       inlined |= state.inline_into(tree);
     }
     if inlined {
-      all_changed.insert(name.to_owned());
+      all_changed.insert(name.clone());
     }
+    new_defs.insert(name, net);
   }
+
+  book.defs = new_defs;
   Ok(all_changed)
 }
 
 #[derive(Debug, Default)]
 struct InlineState {
-  inlinees: HashMap<String, Tree>,
+  inlinees: BTreeMap<String, Tree>,
 }
 
 impl InlineState {
   fn populate_inlinees(&mut self, book: &Book) -> Result<(), String> {
     for (name, net) in &book.defs {
       if should_inline(net) {
-        // Detect cycles with tortoise and hare algorithm
-        let mut hare = &net.root;
-        let mut tortoise = &net.root;
-        // Whether or not the tortoise should take a step
-        let mut parity = false;
-        while let Tree::Ref { nam, .. } = hare {
-          let Some(net) = &book.defs.get(nam) else { break };
-          if should_inline(net) {
-            hare = &net.root;
-          } else {
-            break;
-          }
-          if parity {
-            let Tree::Ref { nam: tortoise_nam, .. } = tortoise else { unreachable!() };
-            if tortoise_nam == nam {
-              Err(format!("infinite reference cycle in `@{nam}`"))?;
-            }
-            tortoise = &book.defs[tortoise_nam].root;
-          }
-          parity = !parity;
-        }
+        let hare = self.find_inlineable(book, name)?;
         self.inlinees.insert(name.to_owned(), hare.clone());
       }
     }
     Ok(())
   }
-  fn inline_into(&self, tree: &mut Tree) -> bool {
-    maybe_grow(|| {
-      let Tree::Ref { nam, .. } = &*tree else {
-        return tree_children_mut(tree).map(|t| self.inline_into(t)).fold(false, bool::bitor);
-      };
-      if let Some(inlined) = self.inlinees.get(nam) {
-        *tree = inlined.clone();
-        true
-      } else {
-        false
+
+  fn find_inlineable<'a>(&self, book: &'a Book, start: &str) -> Result<&'a Tree, String> {
+    let mut hare = &book.defs[start].root;
+    let mut tortoise = hare; // Detect cycles with tortoise and hare algorithm
+    let mut parity = false; // Whether or not the tortoise should take a step
+    while let Tree::Ref { nam, .. } = hare {
+      let Some(net) = book.defs.get(nam) else { break };
+      if !should_inline(net) {
+        break;
       }
+      hare = &net.root;
+      if parity {
+        if let Tree::Ref { nam: tortoise_nam, .. } = tortoise {
+          if tortoise_nam == nam {
+            return Err(format!("infinite reference cycle in `@{nam}`"));
+          }
+          tortoise = &book.defs[tortoise_nam].root;
+        }
+      }
+      parity = !parity;
+    }
+    Ok(hare)
+  }
+
+  fn inline_into(&self, tree: &mut Tree) -> bool {
+    maybe_grow(|| match tree {
+      Tree::Ref { nam, .. } => {
+        if let Some(inlined) = self.inlinees.get(nam) {
+          *tree = inlined.clone();
+          true
+        } else {
+          false
+        }
+      }
+      _ => tree_children_mut(tree).map(|t| self.inline_into(t)).fold(false, BitOr::bitor),
     })
   }
 }

--- a/src/hvm/mod.rs
+++ b/src/hvm/mod.rs
@@ -1,5 +1,6 @@
 use crate::multi_iterator;
 use hvm::ast::{Net, Tree};
+use std::fmt::Write;
 
 pub mod add_recursive_priority;
 pub mod check_net_size;
@@ -37,20 +38,17 @@ pub fn net_trees_mut(net: &mut Net) -> impl DoubleEndedIterator<Item = &mut Tree
 }
 
 pub fn hvm_book_show_pretty(book: &hvm::ast::Book) -> String {
-  let mut s = String::new();
+  let mut s = String::with_capacity(book.defs.len());
   for (nam, def) in book.defs.iter() {
-    s.push_str(&format!("@{} = {}\n", nam, def.root.show()));
+    let _ = writeln!(&mut s, "@{} = {}", nam, def.root.show());
     for (pri, a, b) in def.rbag.iter() {
-      s.push_str("  &");
+      let _ = write!(&mut s, "  &");
       if *pri {
         s.push('!');
       } else {
         s.push(' ');
       }
-      s.push_str(&a.show());
-      s.push_str(" ~ ");
-      s.push_str(&b.show());
-      s.push('\n');
+      let _ = writeln!(&mut s, "{} ~ {}", a.show(), b.show());
     }
     s.push('\n');
   }


### PR DESCRIPTION
**[hvm_book_show_pretty](https://github.com/HigherOrderCO/Bend/blob/2b401e7e8a53a8e90544e06aab16bc5f504d3b6a/src/hvm/mod.rs#L39)**

- Uses write!() and writeln!() macros instead of push_str() and format!()
- pre-allocates string capacity: String::with_capacity(book.defs.len())


```shell
bench_optimized                 ... bench:  64,930,066.60 ns/iter (+/- 5,466,772.94) 

bench_original                  ... bench:  74,655,083.30 ns/iter (+/- 5,307,304.10) 
```
**add hvm benchmark**

```shell
├── benches
│   ├── hvm_common.rs
│   ├── hvm_eta_reduce_benchmarks.rs
│   ├── hvm_inline_benchmarks.rs
│   ├── hvm_mutual_recursion_bench.rs
│   ├── hvm_net_size_benchmarks.rs
│   ├── hvm_prune_book_benchmark.rs
│   └── hvm_utils_benchmarks.rs   
```

<img width="929" alt="image" src="https://github.com/user-attachments/assets/37421217-51ac-4aa0-8b4b-746ff6b82df1">

