### PR TITLE
Fix `String/decode_utf8` returning a non-empty string when given an empty list

### DIFF
--- a/src/fun/builtins.bend
+++ b/src/fun/builtins.bend
@@ -561,7 +561,9 @@ Utf8/REPLACEMENT_CHARACTER : u24 = '\u{FFFD}'
 
 # Decodes a sequence of bytes to a String using utf-8 encoding.
 # Invalid utf-8 sequences are replaced with Utf8/REPLACEMENT_CHARACTER.
-String/decode_utf8 (bytes: (List u24)) : String =
+String/decode_utf8 (bytes: (List u24)) : String
+String/decode_utf8 [] = String/Nil
+String/decode_utf8 bytes =
   let (got, rest) = (Utf8/decode_character bytes)
   match rest {
     List/Nil: (String/Cons got String/Nil)

--- a/tests/golden_tests/io/utf8.bend
+++ b/tests/golden_tests/io/utf8.bend
@@ -5,5 +5,6 @@ v2 = (to-and-back "(λf ((λx (f (x x))) (λx (f (x x)))))")
 v3 = (to-and-back "🌟")
 v4 = (to-and-back "Hello 🌎!")
 v5 = (to-and-back "𓆈 𓆉 𓆊 𓆋 𓅯")
+v6 = (String/decode_utf8 [])
 
-main = [v1, v2, v3, v4, v5]
+main = [v1, v2, v3, v4, v5, v6]

--- a/tests/snapshots/io__utf8.bend.snap
+++ b/tests/snapshots/io__utf8.bend.snap
@@ -3,4 +3,4 @@ source: tests/golden_tests.rs
 input_file: tests/golden_tests/io/utf8.bend
 ---
 Strict mode:
-["hi", "(λf ((λx (f (x x))) (λx (f (x x)))))", "🌟", "Hello 🌎!", "𓆈 𓆉 𓆊 𓆋 𓅯"]
+["hi", "(λf ((λx (f (x x))) (λx (f (x x)))))", "🌟", "Hello 🌎!", "𓆈 𓆉 𓆊 𓆋 𓅯", ""]


### PR DESCRIPTION
Previously calling `(String/decode_utf8 [])` would return `"\0"`.  This PR makes it return `""`, adds this case to `utf8.bend` and updates the snapshot.

Fixes #701