### PR TITLE
Updates builtin type Map so that it stores Maybes in its nodes.

### DIFF
--- a/src/fun/builtins.bend
+++ b/src/fun/builtins.bend
@@ -170,62 +170,111 @@ def Tree/reverse(tree: Tree(T)) -> Tree(T):
     case Tree/Node:
       return ![tree.right, tree.left]
 
+# MAYBE Impl
+
+type Maybe(T):
+  Some { value: T }
+  None 
+
+# Removes the value on a Maybe
+def Maybe/unwrap(m: Maybe(T)) -> T:
+  match m:
+    case Maybe/Some:
+      return m.value
+    case Maybe/None:
+      return unreachable()
+
 # MAP Impl
 
-type Map T = (Node (value: T) ~(left: (Map T)) ~(right: (Map T))) | (Leaf)
+type Map(T):
+  Node { value: Maybe(T), ~left: Map(T), ~right: Map(T) }
+  Leaf  
 
-Map/empty : (Map T) = Map/Leaf
+# Creates an empty Map
+def Map/empty() -> Map(T):
+  return Map/Leaf
 
-Map/get (map: (Map T)) (key: u24) : (T, (Map T)) =
-  match map {
-    Map/Leaf: (unreachable, map)
-    Map/Node:
-      switch _ = (== 0 key) {
-        0: switch _ = (% key 2) {
-          0:
-            let (got, rest) = (Map/get map.left (/ key 2))
-            (got, (Map/Node map.value rest map.right))
-          _:
-            let (got, rest) = (Map/get map.right (/ key 2))
-            (got, (Map/Node map.value map.left rest))
-        }
-        _: (map.value, map)
-      }
-  }
+# Gets a value on a Map
+def Map/get (map: Map(T), key: u24) -> (T, Map(T)):
+  match map:
+    case Map/Leaf:
+      return (unreachable(), map)
+    case Map/Node:
+      if (0 == key):
+        return (Maybe/unwrap(map.value), map)
+      elif (key % 2 == 0):
+        (got, rest) = Map/get(map.left, (key / 2))
+        return(got, Map/Node(map.value, rest, map.right))
+      else:
+        (got, rest) = Map/get(map.right, (key / 2))
+        return(got, Map/Node(map.value, map.left, rest))
 
-Map/set (map: (Map T)) (key: u24) (value: T) : (Map T) =
-  match map {
-    Map/Node:
-      switch _ = (== 0 key) {
-        0: switch _ = (% key 2) {
-          0: (Map/Node map.value (Map/set map.left (/ key 2) value) map.right)
-          _: (Map/Node map.value map.left (Map/set map.right (/ key 2) value))
-        }
-        _: (Map/Node value map.left map.right)
-      }
-    Map/Leaf:
-      switch _ = (== 0 key) {
-        0: switch _ = (% key 2) {
-          0: (Map/Node unreachable (Map/set Map/Leaf (/ key 2) value) Map/Leaf)
-          _: (Map/Node unreachable Map/Leaf (Map/set Map/Leaf (/ key 2) value))
-        }
-        _: (Map/Node value Map/Leaf Map/Leaf)
-      }
-  }
 
-Map/map (map: (Map T)) (key: u24) (f: T -> T) : (Map T)
-Map/map (Map/Leaf)                  key f = Map/Leaf
-Map/map (Map/Node value left right) key f =
-  switch _ = (== 0 key) {
-    0: switch _ = (% key 2) {
-      0:
-        (Map/Node value (Map/map left (/ key 2) f) right)
-      _:
-        (Map/Node value left (Map/map right (/ key 2) f))
-    }
-    _: (Map/Node (f value) left right)
-  }
+# Checks if a node has a value on a given key, returning Maybe/Some if it does, Maybe/None otherwise
+def Map/get_check (map: Map(T), key: u24) -> (Maybe(T), Map(T)):
+  match map:
+    case Map/Leaf:
+      return (Maybe/None, map)
+    case Map/Node:
+      if (0 == key):
+        return (map.value, map)
+      elif (key % 2 == 0):
+        (new_value, new_map) = Map/get_check(map.left, (key / 2))
+        return (new_value, Map/Node(map.value, new_map, map.right))
+      else:
+        (new_value, new_map) = Map/get_check(map.right, (key / 2))
+        return (new_value, Map/Node(map.value, map.left, new_map))
 
+# Sets a value on a Map
+def Map/set (map: Map(T), key: u24, value: T) -> Map(T):
+  match map:
+    case Map/Node:
+      if (0 == key):
+        return Map/Node(Maybe/Some(value), map.left, map.right)
+      elif ((key % 2) == 0):
+        return Map/Node(map.value, Map/set(map.left, (key / 2), value), map.right)
+      else:
+        return Map/Node(map.value, map.left, Map/set(map.right, (key / 2), value))
+    case Map/Leaf:
+      if (0 == key):
+        return Map/Node(Maybe/Some(value), Map/Leaf, Map/Leaf)
+      elif ((key % 2) == 0):
+        return Map/Node(Maybe/None, Map/set(Map/Leaf, (key / 2), value), Map/Leaf)
+      else:
+        return Map/Node(Maybe/None, Map/Leaf, Map/set(Map/Leaf, (key / 2),value))
+
+
+# Checks if a Map contains a given key
+def Map/contains (map: Map(T), key: u24) -> (u24, Map(T)):
+  match map:
+    case Map/Leaf:
+      return (0, map)
+    case Map/Node:
+      if (0 == key):
+        match map.value:
+          case Maybe/Some:
+            return (1, map)
+          case Maybe/None:
+            return (0, map)
+      elif ((key % 2) == 0):
+        (new_value, new_map) = Map/contains(map.left, (key / 2))
+        return (new_value, Map/Node(map.value, new_map, map.right))
+      else:
+        (new_value, new_map) = Map/contains(map.right, (key / 2))
+        return (new_value, Map/Node(map.value, map.left, new_map))
+
+# Applies a funtion to a value on a Map
+def Map/map (map: Map(T), key: u24, f: T -> T) -> Map(T):
+  match map:
+    case Map/Leaf:
+      return Map/Leaf
+    case Map/Node:
+      if (0 == key):
+        return Map/Node(Maybe/Some(f(Maybe/unwrap(map.value))), map.left, map.right)
+      elif ((key % 2) == 0):
+        return Map/Node(map.value, Map/map(map.left, (key / 2), f), map.right)
+      else:
+        return Map/Node(map.value, map.left, Map/map(map.right, (key / 2), f))
 
 # IO Impl
 

--- a/tests/golden_tests.rs
+++ b/tests/golden_tests.rs
@@ -471,6 +471,21 @@ fn io() {
   })
 }
 
+/// Runs a file that uses the prelude.
+#[test]
+fn prelude() {
+  run_golden_test_dir(function_name!(), &|code, path| {
+    let _guard = RUN_MUTEX.lock().unwrap();
+    let book = parse_book_single_file(code, path)?;
+    let compile_opts = CompileOpts::default();
+    let diagnostics_cfg = DiagnosticsConfig::new(Severity::Error, true);
+    let (term, _, diags) =
+      run_book(book, RunOpts::default(), compile_opts, diagnostics_cfg, None, "run-c")?.unwrap();
+    let res = format!("{diags}{term}");
+    Ok(format!("Strict mode:\n{res}"))
+  })
+}
+
 /// Runs all examples in the examples folder.
 #[test]
 fn examples() -> Result<(), Diagnostics> {

--- a/tests/golden_tests/compile_file_o_all/match_adt_non_exhaustive.bend
+++ b/tests/golden_tests/compile_file_o_all/match_adt_non_exhaustive.bend
@@ -1,9 +1,9 @@
-type Maybe = (Some val) | None
+type Maybe_ = (Some val) | None
 
 main = @maybe
   match maybe {
-    Maybe/None: 0
-    Maybe/Some: match maybe.val {
-      Maybe/None: 0
+    Maybe_/None: 0
+    Maybe_/Some: match maybe.val {
+      Maybe_/None: 0
     }
   }

--- a/tests/golden_tests/encode_pattern_match/match_adt_unscoped_lambda.bend
+++ b/tests/golden_tests/encode_pattern_match/match_adt_unscoped_lambda.bend
@@ -1,6 +1,6 @@
-type Maybe = None | (Some val)
+type Maybe_ = None | (Some val)
 
-main = (match x = (Maybe/Some 1) {
-  Maybe/None: @$x *
-  Maybe/Some: x.val
+main = (match x = (Maybe_/Some 1) {
+  Maybe_/None: @$x *
+  Maybe_/Some: x.val
 } $x)

--- a/tests/golden_tests/encode_pattern_match/match_adt_unscoped_var.bend
+++ b/tests/golden_tests/encode_pattern_match/match_adt_unscoped_var.bend
@@ -1,13 +1,13 @@
-type Maybe = None | (Some val)
+type Maybe_ = None | (Some val)
 
-Foo = @$x match x = (Maybe/Some 1) {
-  Maybe/None: $x
-  Maybe/Some: x.val
+Foo = @$x match x = (Maybe_/Some 1) {
+  Maybe_/None: $x
+  Maybe_/Some: x.val
 }
 
-Bar = (match x = (Maybe/Some 1) {
-  Maybe/None: $x
-  Maybe/Some: x.val
+Bar = (match x = (Maybe_/Some 1) {
+  Maybe_/None: $x
+  Maybe_/Some: x.val
 } @$x *)
 
 main = *

--- a/tests/golden_tests/prelude/applies_function_to_map.bend
+++ b/tests/golden_tests/prelude/applies_function_to_map.bend
@@ -1,0 +1,14 @@
+# Checks if a generic map contains a given key, and if it does, applies a function to the value, otherwise it returns the map
+def test(m: Map(u24), key: u24) -> u24:
+  def addtwo (x: u24) -> u24:
+    return (x + 2)
+  (num, map) = Map/contains(m, key)
+  if (num == 0):
+    return unreachable()
+  else:
+    m = Map/map(m, key, addtwo())
+    (value, map) = Map/get(m, key)
+    return value
+def main() -> _:
+  m = {3: 255}
+  return test(m, 3)

--- a/tests/golden_tests/prelude/get_values_from_map.bend
+++ b/tests/golden_tests/prelude/get_values_from_map.bend
@@ -1,0 +1,9 @@
+def test1() -> (u24):
+  m = {}
+  m = Map/set(Map/set(Map/set(Map/empty, 3, 4), 2, 3), 1, 2)
+  (val1, map1) = Map/get(m, 1) 
+  (val2, map2) = Map/get(map1, val1)
+  return val2
+
+def main() -> _:
+  return test1()

--- a/tests/golden_tests/prelude/lists_to_map.bend
+++ b/tests/golden_tests/prelude/lists_to_map.bend
@@ -1,0 +1,14 @@
+# Takes two lists and uses one as keys and the other as values, returning a map
+def test(m: Map(T), xs: List(u24), ys: List(T)) -> Map(T):
+  match xs:
+    case List/Nil:
+      return Map/Leaf
+    case List/Cons:
+      match ys:
+        case List/Nil:
+          return Map/Leaf
+        case List/Cons:
+          return test(Map/set(m, xs.head, ys.head), xs.tail, ys.tail)
+
+def main() -> _:
+  return test(Map/Leaf, List/Cons(1, List/Nil), List/Cons(2, List/Nil))

--- a/tests/golden_tests/prelude/map_checked_test.bend
+++ b/tests/golden_tests/prelude/map_checked_test.bend
@@ -1,0 +1,5 @@
+#Tests the get_check function
+def main() -> _:
+  m1 = {0: 1, 3: 2} 
+  return Map/get_check(m1, 3)
+

--- a/tests/golden_tests/prelude/map_contains_test.bend
+++ b/tests/golden_tests/prelude/map_contains_test.bend
@@ -1,0 +1,3 @@
+def main() -> _:
+  m1 = {0: 23} 
+  return Map/contains(m1, 3)

--- a/tests/golden_tests/prelude/set_node_when_empty.bend
+++ b/tests/golden_tests/prelude/set_node_when_empty.bend
@@ -1,0 +1,12 @@
+# Sets a value if the given node is empty, otherwise returns the map
+def test(m: Map(T), x: u24, v: T) -> Map(T):
+  (val, map) = Map/get_check(m, x)
+  match val:
+    case Maybe/Some:
+      return m
+    case Maybe/None:
+      return Map/set(m, x, v)
+
+def main() -> _:
+  m = {0: 42, 1:23} 
+  return test(m, 3, 4)

--- a/tests/golden_tests/run_file/unbound_wrap.bend
+++ b/tests/golden_tests/run_file/unbound_wrap.bend
@@ -1,10 +1,10 @@
-type Maybe = (Some x) | None
+type Maybe_ = (Some x) | None
 
-Maybe/bind val nxt = match val {
-  Maybe/Some: (nxt val.x)
-  Maybe/None: Maybe/None
+Maybe_/bind val nxt = match val {
+  Maybe_/Some: (nxt val.x)
+  Maybe_/None: Maybe_/None
 }
 
-main = with Maybe {
+main = with Maybe_ {
   (wrap 1)
 }

--- a/tests/golden_tests/simplify_matches/double_unwrap_maybe.bend
+++ b/tests/golden_tests/simplify_matches/double_unwrap_maybe.bend
@@ -1,7 +1,7 @@
 # We want to make sure that the default value is not mistakenly erased in the first level of flattening.
-type Maybe = (Some x) | None
+type Maybe_ = (Some x) | None
 
-(DoubleUnwrap (Maybe/Some (Maybe/Some x)) *) = x
+(DoubleUnwrap (Maybe_/Some (Maybe_/Some x)) *) = x
 (DoubleUnwrap * x) = x
 
-Main = (DoubleUnwrap (Maybe/Some Maybe/None) 5)
+Main = (DoubleUnwrap (Maybe_/Some Maybe_/None) 5)

--- a/tests/snapshots/compile_file_o_all__match_adt_non_exhaustive.bend.snap
+++ b/tests/snapshots/compile_file_o_all__match_adt_non_exhaustive.bend.snap
@@ -5,4 +5,4 @@ input_file: tests/golden_tests/compile_file_o_all/match_adt_non_exhaustive.bend
 [4m[1m[31mErrors:[0m
 [1mIn [4mtests/golden_tests/compile_file_o_all/match_adt_non_exhaustive.bend[0m[1m :[0m
 [1mIn definition '[4mmain[0m[1m':[0m
-  Non-exhaustive 'match' expression of type 'Maybe'. Case 'Maybe/Some' not covered.
+  Non-exhaustive 'match' expression of type 'Maybe_'. Case 'Maybe_/Some' not covered.

--- a/tests/snapshots/desugar_file__mapper_syntax.bend.snap
+++ b/tests/snapshots/desugar_file__mapper_syntax.bend.snap
@@ -2,6 +2,9 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/desugar_file/mapper_syntax.bend
 ---
+Maybe/unwrap: ((Maybe a) -> a)
+(Maybe/unwrap) = λa (a Maybe/unwrap__C0)
+
 Map/empty: (Map a)
 (Map/empty) = Map/Leaf
 
@@ -20,10 +23,22 @@ unreachable: Any
 unchecked main: Any
 (main) = let (c, d) = (Map/get (Map/map (Map/map (Map/set (Map/set Map/empty 0 3) 1 4) 1 λa (+ a 1)) 1 λb (* b 2)) 1); let (e, *) = (Map/get d 0); ((λf (+ f 1) 1), c, e)
 
+Maybe/Some/tag: u24
+(Maybe/Some/tag) = 0
+
+Maybe/Some: (a -> (Maybe a))
+(Maybe/Some) = λa λb (b Maybe/Some/tag a)
+
+Maybe/None/tag: u24
+(Maybe/None/tag) = 1
+
+Maybe/None: (Maybe a)
+(Maybe/None) = λa (a Maybe/None/tag)
+
 Map/Node/tag: u24
 (Map/Node/tag) = 0
 
-Map/Node: (a -> (Map a) -> (Map a) -> (Map a))
+Map/Node: ((Maybe a) -> (Map a) -> (Map a) -> (Map a))
 (Map/Node) = λa λb λc λd (d Map/Node/tag a b c)
 
 Map/Leaf/tag: u24
@@ -33,16 +48,16 @@ Map/Leaf: (Map a)
 (Map/Leaf) = λa (a Map/Leaf/tag)
 
 Map/get__C0: _
-(Map/get__C0) = λa λb λc λd let (e, f) = (Map/get c (/ a 2)); (e, (Map/Node b f d))
+(Map/get__C0) = λa λb λc λd let (e, f) = (Map/get d (/ a 2)); (e, (Map/Node b c f))
 
 Map/get__C1: _
-(Map/get__C1) = λ* λa λb λc λd let (e, f) = (Map/get d (/ a 2)); (e, (Map/Node b c f))
+(Map/get__C1) = λ* λa λb λc λd let (e, f) = (Map/get c (/ a 2)); (e, (Map/Node b f d))
 
 Map/get__C2: _
-(Map/get__C2) = λa let {b c} = a; λd λe λf (switch (% b 2) { 0: Map/get__C0; _: Map/get__C1; } c d e f)
+(Map/get__C2) = λa let {b c} = a; λd λe λf (switch (== (% b 2) 0) { 0: Map/get__C0; _: Map/get__C1; } c d e f)
 
 Map/get__C3: _
-(Map/get__C3) = λ* λ* λa let {b c} = a; λd λe (b, (Map/Node c d e))
+(Map/get__C3) = λ* λ* λa let {b c} = a; λd λe ((Maybe/unwrap b), (Map/Node c d e))
 
 Map/get__C4: _
 (Map/get__C4) = λa λb λc λd let {e f} = d; (switch (== 0 e) { 0: Map/get__C2; _: Map/get__C3; } f a b c)
@@ -51,16 +66,16 @@ Map/get__C5: _
 (Map/get__C5) = λa switch a { 0: Map/get__C4; _: λ* λ* (unreachable, Map/Leaf); }
 
 Map/map__C0: _
-(Map/map__C0) = λa λb λc λd λe (Map/Node c (Map/map d (/ a 2) b) e)
+(Map/map__C0) = λa λb λc λd λe (Map/Node c d (Map/map e (/ a 2) b))
 
 Map/map__C1: _
-(Map/map__C1) = λ* λa λb λc λd λe (Map/Node c d (Map/map e (/ a 2) b))
+(Map/map__C1) = λ* λa λb λc λd λe (Map/Node c (Map/map d (/ a 2) b) e)
 
 Map/map__C2: _
-(Map/map__C2) = λa let {b c} = a; λd λe λf λg (switch (% b 2) { 0: Map/map__C0; _: Map/map__C1; } c d e f g)
+(Map/map__C2) = λa let {b c} = a; λd λe λf λg (switch (== (% b 2) 0) { 0: Map/map__C0; _: Map/map__C1; } c d e f g)
 
 Map/map__C3: _
-(Map/map__C3) = λ* λ* λa λb λc λd (Map/Node (a b) c d)
+(Map/map__C3) = λ* λ* λa λb λc λd (Map/Node (Maybe/Some (a (Maybe/unwrap b))) c d)
 
 Map/map__C4: _
 (Map/map__C4) = λa λb λc λd let {e f} = d; λg (switch (== 0 e) { 0: Map/map__C2; _: Map/map__C3; } f g a b c)
@@ -69,34 +84,37 @@ Map/map__C5: _
 (Map/map__C5) = λa switch a { 0: Map/map__C4; _: λ* λ* λ* Map/Leaf; }
 
 Map/set__C0: _
-(Map/set__C0) = λa λb λc λd λe (Map/Node c (Map/set d (/ a 2) b) e)
+(Map/set__C0) = λa λb λc λd λe (Map/Node c d (Map/set e (/ a 2) b))
 
 Map/set__C1: _
-(Map/set__C1) = λ* λa λb λc λd λe (Map/Node c d (Map/set e (/ a 2) b))
+(Map/set__C1) = λ* λa λb λc λd λe (Map/Node c (Map/set d (/ a 2) b) e)
 
 Map/set__C10: _
 (Map/set__C10) = λa switch a { 0: Map/set__C8; _: Map/set__C9; }
 
 Map/set__C2: _
-(Map/set__C2) = λa let {b c} = a; λd λe λf λg (switch (% b 2) { 0: Map/set__C0; _: Map/set__C1; } c d e f g)
+(Map/set__C2) = λa let {b c} = a; λd λe λf λg (switch (== (% b 2) 0) { 0: Map/set__C0; _: Map/set__C1; } c d e f g)
 
 Map/set__C3: _
-(Map/set__C3) = λ* λ* λa λ* λb λc (Map/Node a b c)
+(Map/set__C3) = λ* λ* λa λ* λb λc (Map/Node (Maybe/Some a) b c)
 
 Map/set__C4: _
-(Map/set__C4) = λa λb (Map/Node unreachable (Map/set Map/Leaf (/ a 2) b) Map/Leaf)
+(Map/set__C4) = λa λb (Map/Node Maybe/None Map/Leaf (Map/set Map/Leaf (/ a 2) b))
 
 Map/set__C5: _
-(Map/set__C5) = λ* λa λb (Map/Node unreachable Map/Leaf (Map/set Map/Leaf (/ a 2) b))
+(Map/set__C5) = λ* λa λb (Map/Node Maybe/None (Map/set Map/Leaf (/ a 2) b) Map/Leaf)
 
 Map/set__C6: _
-(Map/set__C6) = λa let {b c} = a; λd (switch (% b 2) { 0: Map/set__C4; _: Map/set__C5; } c d)
+(Map/set__C6) = λa let {b c} = a; λd (switch (== (% b 2) 0) { 0: Map/set__C4; _: Map/set__C5; } c d)
 
 Map/set__C7: _
-(Map/set__C7) = λ* λ* λa (Map/Node a Map/Leaf Map/Leaf)
+(Map/set__C7) = λ* λ* λa (Map/Node (Maybe/Some a) Map/Leaf Map/Leaf)
 
 Map/set__C8: _
 (Map/set__C8) = λa λb λc λd let {e f} = d; λg (switch (== 0 e) { 0: Map/set__C2; _: Map/set__C3; } f g a b c)
 
 Map/set__C9: _
 (Map/set__C9) = λ* λa let {b c} = a; λd (switch (== 0 b) { 0: Map/set__C6; _: Map/set__C7; } c d)
+
+Maybe/unwrap__C0: _
+(Maybe/unwrap__C0) = λa switch a { 0: λb b; _: λ* unreachable; }

--- a/tests/snapshots/encode_pattern_match__full_map.bend.snap
+++ b/tests/snapshots/encode_pattern_match__full_map.bend.snap
@@ -3,8 +3,11 @@ source: tests/golden_tests.rs
 input_file: tests/golden_tests/encode_pattern_match/full_map.bend
 ---
 Scott
+Maybe/unwrap: ((Maybe T) -> T)
+(Maybe/unwrap) = λa (a λb b unreachable)
+
 Map/get: ((Map T) -> u24 -> (T, (Map T)))
-(Map/get) = λa (a λb let {b b_2 b_3 b_4} = b; λc let {c c_2 c_3} = c; λd let {d d_2 d_3} = d; λe let {e e_2 e_3 e_4} = e; switch (== 0 e) { 0: switch (% e_2 2) { 0: let (f, g) = (Map/get c (/ e_3 2)); (f, (Map/Node b g d)); _: λ* let (i, j) = (Map/get d_2 (/ e_4 2)); (i, (Map/Node b_2 c_2 j)); }; _: λ* (b_3, (Map/Node b_4 c_3 d_3)); } λ* (unreachable, Map/Leaf))
+(Map/get) = λa (a λb let {b b_2 b_3 b_4} = b; λc let {c c_2 c_3} = c; λd let {d d_2 d_3} = d; λe let {e e_2 e_3 e_4} = e; switch (== 0 e) { 0: switch (== (% e_2 2) 0) { 0: let (f, g) = (Map/get d (/ e_3 2)); (f, (Map/Node b c g)); _: λ* let (i, j) = (Map/get c_2 (/ e_4 2)); (i, (Map/Node b_2 j d_2)); }; _: λ* ((Maybe/unwrap b_3), (Map/Node b_4 c_3 d_3)); } λ* (unreachable, Map/Leaf))
 
 unreachable: Any
 (unreachable) = *
@@ -21,7 +24,7 @@ unchecked test: (Any -> Any)
 unchecked main: Any
 (main) = (test fullMap)
 
-Map/Node: (T -> (Map T) -> (Map T) -> (Map T))
+Map/Node: ((Maybe T) -> (Map T) -> (Map T) -> (Map T))
 (Map/Node) = λa λb λc λd λ* (d a b c)
 
 Map/Leaf: (Map T)
@@ -34,8 +37,11 @@ unchecked test__bend0: _
 (test__bend0) = λa let {a a_2 a_3} = a; switch (< a 1000) { 0: λ* 0; _: λ* λd let (e, f) = (Map/get d (% (prng a_2) 4096)); (+ e (test__bend0 (+ a_3 1) f)); }
 
 NumScott
+Maybe/unwrap: ((Maybe T) -> T)
+(Maybe/unwrap) = λa (a λb switch b { 0: λc c; _: λ* unreachable; })
+
 Map/get: ((Map T) -> u24 -> (T, (Map T)))
-(Map/get) = λa (a λb switch b { 0: λc let {c c_2 c_3 c_4} = c; λd let {d d_2 d_3} = d; λe let {e e_2 e_3} = e; λf let {f f_2 f_3 f_4} = f; switch (== 0 f) { 0: switch (% f_2 2) { 0: let (g, h) = (Map/get d (/ f_3 2)); (g, (Map/Node c h e)); _: λ* let (j, k) = (Map/get e_2 (/ f_4 2)); (j, (Map/Node c_2 d_2 k)); }; _: λ* (c_3, (Map/Node c_4 d_3 e_3)); }; _: λ* λ* (unreachable, Map/Leaf); })
+(Map/get) = λa (a λb switch b { 0: λc let {c c_2 c_3 c_4} = c; λd let {d d_2 d_3} = d; λe let {e e_2 e_3} = e; λf let {f f_2 f_3 f_4} = f; switch (== 0 f) { 0: switch (== (% f_2 2) 0) { 0: let (g, h) = (Map/get e (/ f_3 2)); (g, (Map/Node c d h)); _: λ* let (j, k) = (Map/get d_2 (/ f_4 2)); (j, (Map/Node c_2 k e_2)); }; _: λ* ((Maybe/unwrap c_3), (Map/Node c_4 d_3 e_3)); }; _: λ* λ* (unreachable, Map/Leaf); })
 
 unreachable: Any
 (unreachable) = *
@@ -55,7 +61,7 @@ unchecked main: Any
 Map/Node/tag: _
 (Map/Node/tag) = 0
 
-Map/Node: (T -> (Map T) -> (Map T) -> (Map T))
+Map/Node: ((Maybe T) -> (Map T) -> (Map T) -> (Map T))
 (Map/Node) = λa λb λc λd (d Map/Node/tag a b c)
 
 Map/Leaf/tag: _

--- a/tests/snapshots/encode_pattern_match__match_adt_unscoped_lambda.bend.snap
+++ b/tests/snapshots/encode_pattern_match__match_adt_unscoped_lambda.bend.snap
@@ -4,26 +4,26 @@ input_file: tests/golden_tests/encode_pattern_match/match_adt_unscoped_lambda.be
 ---
 Scott
 unchecked main: Any
-(main) = (Maybe/Some 1 λ$x * λa a $x)
+(main) = (Maybe_/Some 1 λ$x * λa a $x)
 
-Maybe/None: Maybe
-(Maybe/None) = λa λ* a
+Maybe_/None: Maybe_
+(Maybe_/None) = λa λ* a
 
-Maybe/Some: (Any -> Maybe)
-(Maybe/Some) = λa λ* λc (c a)
+Maybe_/Some: (Any -> Maybe_)
+(Maybe_/Some) = λa λ* λc (c a)
 
 NumScott
 unchecked main: Any
-(main) = (Maybe/Some 1 λa switch a { 0: λ$x *; _: λ* λb b; } $x)
+(main) = (Maybe_/Some 1 λa switch a { 0: λ$x *; _: λ* λb b; } $x)
 
-Maybe/None/tag: _
-(Maybe/None/tag) = 0
+Maybe_/None/tag: _
+(Maybe_/None/tag) = 0
 
-Maybe/None: Maybe
-(Maybe/None) = λa (a Maybe/None/tag)
+Maybe_/None: Maybe_
+(Maybe_/None) = λa (a Maybe_/None/tag)
 
-Maybe/Some/tag: _
-(Maybe/Some/tag) = 1
+Maybe_/Some/tag: _
+(Maybe_/Some/tag) = 1
 
-Maybe/Some: (Any -> Maybe)
-(Maybe/Some) = λa λb (b Maybe/Some/tag a)
+Maybe_/Some: (Any -> Maybe_)
+(Maybe_/Some) = λa λb (b Maybe_/Some/tag a)

--- a/tests/snapshots/encode_pattern_match__match_adt_unscoped_var.bend.snap
+++ b/tests/snapshots/encode_pattern_match__match_adt_unscoped_var.bend.snap
@@ -4,38 +4,38 @@ input_file: tests/golden_tests/encode_pattern_match/match_adt_unscoped_var.bend
 ---
 Scott
 unchecked Foo: Any
-(Foo) = λ$x (Maybe/Some 1 $x λa a)
+(Foo) = λ$x (Maybe_/Some 1 $x λa a)
 
 unchecked Bar: Any
-(Bar) = (Maybe/Some 1 $x λa a λ$x *)
+(Bar) = (Maybe_/Some 1 $x λa a λ$x *)
 
 unchecked main: Any
 (main) = *
 
-Maybe/None: Maybe
-(Maybe/None) = λa λ* a
+Maybe_/None: Maybe_
+(Maybe_/None) = λa λ* a
 
-Maybe/Some: (Any -> Maybe)
-(Maybe/Some) = λa λ* λc (c a)
+Maybe_/Some: (Any -> Maybe_)
+(Maybe_/Some) = λa λ* λc (c a)
 
 NumScott
 unchecked Foo: Any
-(Foo) = λ$x (Maybe/Some 1 λa switch a { 0: $x; _: λ* λb b; })
+(Foo) = λ$x (Maybe_/Some 1 λa switch a { 0: $x; _: λ* λb b; })
 
 unchecked Bar: Any
-(Bar) = (Maybe/Some 1 λa switch a { 0: $x; _: λ* λb b; } λ$x *)
+(Bar) = (Maybe_/Some 1 λa switch a { 0: $x; _: λ* λb b; } λ$x *)
 
 unchecked main: Any
 (main) = *
 
-Maybe/None/tag: _
-(Maybe/None/tag) = 0
+Maybe_/None/tag: _
+(Maybe_/None/tag) = 0
 
-Maybe/None: Maybe
-(Maybe/None) = λa (a Maybe/None/tag)
+Maybe_/None: Maybe_
+(Maybe_/None) = λa (a Maybe_/None/tag)
 
-Maybe/Some/tag: _
-(Maybe/Some/tag) = 1
+Maybe_/Some/tag: _
+(Maybe_/Some/tag) = 1
 
-Maybe/Some: (Any -> Maybe)
-(Maybe/Some) = λa λb (b Maybe/Some/tag a)
+Maybe_/Some: (Any -> Maybe_)
+(Maybe_/Some) = λa λb (b Maybe_/Some/tag a)

--- a/tests/snapshots/parse_file__imp_map.bend.snap
+++ b/tests/snapshots/parse_file__imp_map.bend.snap
@@ -2,14 +2,17 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/parse_file/imp_map.bend
 ---
+Maybe/unwrap: ((Maybe T) -> T)
+(Maybe/unwrap m) = match m = m { Maybe/Some: m.value; Maybe/None: unreachable; }
+
 Map/empty: (Map T)
 (Map/empty) = Map/Leaf
 
 Map/get: ((Map T) -> u24 -> (T, (Map T)))
-(Map/get map key) = match map = map { Map/Leaf: (unreachable, map); Map/Node: switch _ = (== 0 key) { 0: switch _ = (% key 2) { 0: let (got, rest) = (Map/get map.left (/ key 2)); (got, (Map/Node map.value rest map.right)); _ _-1: let (got, rest) = (Map/get map.right (/ key 2)); (got, (Map/Node map.value map.left rest)); }; _ _-1: (map.value, map); }; }
+(Map/get map key) = match map = map { Map/Leaf: (unreachable, map); Map/Node: switch %pred = (== 0 key) { 0: switch %pred = (== (% key 2) 0) { 0: let (got, rest) = (Map/get map.right (/ key 2)); (got, (Map/Node map.value map.left rest)); _ %pred-1: let (got, rest) = (Map/get map.left (/ key 2)); (got, (Map/Node map.value rest map.right)); }; _ %pred-1: ((Maybe/unwrap map.value), map); }; }
 
 Map/set: ((Map T) -> u24 -> T -> (Map T))
-(Map/set map key value) = match map = map { Map/Node: switch _ = (== 0 key) { 0: switch _ = (% key 2) { 0: (Map/Node map.value (Map/set map.left (/ key 2) value) map.right); _ _-1: (Map/Node map.value map.left (Map/set map.right (/ key 2) value)); }; _ _-1: (Map/Node value map.left map.right); }; Map/Leaf: switch _ = (== 0 key) { 0: switch _ = (% key 2) { 0: (Map/Node unreachable (Map/set Map/Leaf (/ key 2) value) Map/Leaf); _ _-1: (Map/Node unreachable Map/Leaf (Map/set Map/Leaf (/ key 2) value)); }; _ _-1: (Map/Node value Map/Leaf Map/Leaf); }; }
+(Map/set map key value) = match map = map { Map/Node: switch %pred = (== 0 key) { 0: switch %pred = (== (% key 2) 0) { 0: (Map/Node map.value map.left (Map/set map.right (/ key 2) value)); _ %pred-1: (Map/Node map.value (Map/set map.left (/ key 2) value) map.right); }; _ %pred-1: (Map/Node (Maybe/Some value) map.left map.right); }; Map/Leaf: switch %pred = (== 0 key) { 0: switch %pred = (== (% key 2) 0) { 0: (Map/Node Maybe/None Map/Leaf (Map/set Map/Leaf (/ key 2) value)); _ %pred-1: (Map/Node Maybe/None (Map/set Map/Leaf (/ key 2) value) Map/Leaf); }; _ %pred-1: (Map/Node (Maybe/Some value) Map/Leaf Map/Leaf); }; }
 
 unreachable: Any
 (unreachable) = *
@@ -17,10 +20,22 @@ unreachable: Any
 unchecked main: Any
 (main) = let x = (Map/set (Map/set Map/empty 2 1) 3 2); let (map/get%1, x) = (Map/get x 2); let y = (id map/get%1); let z = 4; let x = (Map/set x z 4); let (map/get%0, x) = (Map/get x z); (+ y map/get%0)
 
+Maybe/Some/tag: _
+(Maybe/Some/tag) = 0
+
+Maybe/Some: (T -> (Maybe T))
+(Maybe/Some) = λvalue λ%x (%x Maybe/Some/tag value)
+
+Maybe/None/tag: _
+(Maybe/None/tag) = 1
+
+Maybe/None: (Maybe T)
+(Maybe/None) = λ%x (%x Maybe/None/tag)
+
 Map/Node/tag: _
 (Map/Node/tag) = 0
 
-Map/Node: (T -> (Map T) -> (Map T) -> (Map T))
+Map/Node: ((Maybe T) -> (Map T) -> (Map T) -> (Map T))
 (Map/Node) = λvalue λleft λright λ%x (%x Map/Node/tag value left right)
 
 Map/Leaf/tag: _

--- a/tests/snapshots/parse_file__imp_program.bend.snap
+++ b/tests/snapshots/parse_file__imp_program.bend.snap
@@ -2,14 +2,17 @@
 source: tests/golden_tests.rs
 input_file: tests/golden_tests/parse_file/imp_program.bend
 ---
+Maybe/unwrap: ((Maybe T) -> T)
+(Maybe/unwrap m) = match m = m { Maybe/Some: m.value; Maybe/None: unreachable; }
+
 Map/empty: (Map T)
 (Map/empty) = Map/Leaf
 
 Map/get: ((Map T) -> u24 -> (T, (Map T)))
-(Map/get map key) = match map = map { Map/Leaf: (unreachable, map); Map/Node: switch _ = (== 0 key) { 0: switch _ = (% key 2) { 0: let (got, rest) = (Map/get map.left (/ key 2)); (got, (Map/Node map.value rest map.right)); _ _-1: let (got, rest) = (Map/get map.right (/ key 2)); (got, (Map/Node map.value map.left rest)); }; _ _-1: (map.value, map); }; }
+(Map/get map key) = match map = map { Map/Leaf: (unreachable, map); Map/Node: switch %pred = (== 0 key) { 0: switch %pred = (== (% key 2) 0) { 0: let (got, rest) = (Map/get map.right (/ key 2)); (got, (Map/Node map.value map.left rest)); _ %pred-1: let (got, rest) = (Map/get map.left (/ key 2)); (got, (Map/Node map.value rest map.right)); }; _ %pred-1: ((Maybe/unwrap map.value), map); }; }
 
 Map/set: ((Map T) -> u24 -> T -> (Map T))
-(Map/set map key value) = match map = map { Map/Node: switch _ = (== 0 key) { 0: switch _ = (% key 2) { 0: (Map/Node map.value (Map/set map.left (/ key 2) value) map.right); _ _-1: (Map/Node map.value map.left (Map/set map.right (/ key 2) value)); }; _ _-1: (Map/Node value map.left map.right); }; Map/Leaf: switch _ = (== 0 key) { 0: switch _ = (% key 2) { 0: (Map/Node unreachable (Map/set Map/Leaf (/ key 2) value) Map/Leaf); _ _-1: (Map/Node unreachable Map/Leaf (Map/set Map/Leaf (/ key 2) value)); }; _ _-1: (Map/Node value Map/Leaf Map/Leaf); }; }
+(Map/set map key value) = match map = map { Map/Node: switch %pred = (== 0 key) { 0: switch %pred = (== (% key 2) 0) { 0: (Map/Node map.value map.left (Map/set map.right (/ key 2) value)); _ %pred-1: (Map/Node map.value (Map/set map.left (/ key 2) value) map.right); }; _ %pred-1: (Map/Node (Maybe/Some value) map.left map.right); }; Map/Leaf: switch %pred = (== 0 key) { 0: switch %pred = (== (% key 2) 0) { 0: (Map/Node Maybe/None Map/Leaf (Map/set Map/Leaf (/ key 2) value)); _ %pred-1: (Map/Node Maybe/None (Map/set Map/Leaf (/ key 2) value) Map/Leaf); }; _ %pred-1: (Map/Node (Maybe/Some value) Map/Leaf Map/Leaf); }; }
 
 unreachable: Any
 (unreachable) = *
@@ -71,10 +74,22 @@ List/Cons/tag: _
 List/Cons: (T -> (List T) -> (List T))
 (List/Cons) = λhead λtail λ%x (%x List/Cons/tag head tail)
 
+Maybe/Some/tag: _
+(Maybe/Some/tag) = 0
+
+Maybe/Some: (T -> (Maybe T))
+(Maybe/Some) = λvalue λ%x (%x Maybe/Some/tag value)
+
+Maybe/None/tag: _
+(Maybe/None/tag) = 1
+
+Maybe/None: (Maybe T)
+(Maybe/None) = λ%x (%x Maybe/None/tag)
+
 Map/Node/tag: _
 (Map/Node/tag) = 0
 
-Map/Node: (T -> (Map T) -> (Map T) -> (Map T))
+Map/Node: ((Maybe T) -> (Map T) -> (Map T) -> (Map T))
 (Map/Node) = λvalue λleft λright λ%x (%x Map/Node/tag value left right)
 
 Map/Leaf/tag: _

--- a/tests/snapshots/prelude__applies_function_to_map.bend.snap
+++ b/tests/snapshots/prelude__applies_function_to_map.bend.snap
@@ -1,0 +1,6 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/prelude/applies_function_to_map.bend
+---
+Strict mode:
+257

--- a/tests/snapshots/prelude__get_values_from_map.bend.snap
+++ b/tests/snapshots/prelude__get_values_from_map.bend.snap
@@ -1,0 +1,6 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/prelude/get_values_from_map.bend
+---
+Strict mode:
+3

--- a/tests/snapshots/prelude__lists_to_map.bend.snap
+++ b/tests/snapshots/prelude__lists_to_map.bend.snap
@@ -1,0 +1,6 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/prelude/lists_to_map.bend
+---
+Strict mode:
+Map/Leaf

--- a/tests/snapshots/prelude__map_checked_test.bend.snap
+++ b/tests/snapshots/prelude__map_checked_test.bend.snap
@@ -1,0 +1,6 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/prelude/map_checked_test.bend
+---
+Strict mode:
+(λa (a Maybe/Some/tag 2), λb (b Map/Node/tag λc (c Maybe/Some/tag 1) Map/Leaf λd (d Map/Node/tag Maybe/None Map/Leaf λe (e Map/Node/tag λf (f Maybe/Some/tag 2) Map/Leaf Map/Leaf))))

--- a/tests/snapshots/prelude__map_contains_test.bend.snap
+++ b/tests/snapshots/prelude__map_contains_test.bend.snap
@@ -1,0 +1,6 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/prelude/map_contains_test.bend
+---
+Strict mode:
+(0, λa (a Map/Node/tag λb (b Maybe/Some/tag 23) Map/Leaf Map/Leaf))

--- a/tests/snapshots/prelude__set_node_when_empty.bend.snap
+++ b/tests/snapshots/prelude__set_node_when_empty.bend.snap
@@ -1,0 +1,6 @@
+---
+source: tests/golden_tests.rs
+input_file: tests/golden_tests/prelude/set_node_when_empty.bend
+---
+Strict mode:
+λa (a Map/Node/tag λb (b Maybe/Some/tag 42) Map/Leaf λc (c Map/Node/tag λd (d Maybe/Some/tag 23) Map/Leaf λe (e Map/Node/tag λf (f Maybe/Some/tag 4) Map/Leaf Map/Leaf)))

--- a/tests/snapshots/run_file__unbound_wrap.bend.snap
+++ b/tests/snapshots/run_file__unbound_wrap.bend.snap
@@ -5,4 +5,4 @@ input_file: tests/golden_tests/run_file/unbound_wrap.bend
 [4m[1m[31mErrors:[0m
 [1mIn [4mtests/golden_tests/run_file/unbound_wrap.bend[0m[1m :[0m
 [1mIn definition '[4mmain[0m[1m':[0m
-  Reference to undefined function 'Maybe/wrap'
+  Reference to undefined function 'Maybe_/wrap'

--- a/tests/snapshots/simplify_matches__double_unwrap_maybe.bend.snap
+++ b/tests/snapshots/simplify_matches__double_unwrap_maybe.bend.snap
@@ -3,19 +3,19 @@ source: tests/golden_tests.rs
 input_file: tests/golden_tests/simplify_matches/double_unwrap_maybe.bend
 ---
 unchecked DoubleUnwrap: Any
-(DoubleUnwrap) = λa match a { Maybe/Some b: match b { Maybe/Some c: λd let e = d; let f = e; c; Maybe/None: λg let h = g; let i = h; i; }; Maybe/None: λj let k = j; k; }
+(DoubleUnwrap) = λa match a { Maybe_/Some b: match b { Maybe_/Some c: λd let e = d; let f = e; c; Maybe_/None: λg let h = g; let i = h; i; }; Maybe_/None: λj let k = j; k; }
 
 unchecked Main: Any
-(Main) = (DoubleUnwrap (Maybe/Some Maybe/None) 5)
+(Main) = (DoubleUnwrap (Maybe_/Some Maybe_/None) 5)
 
-Maybe/Some/tag: _
-(Maybe/Some/tag) = 0
+Maybe_/Some/tag: _
+(Maybe_/Some/tag) = 0
 
-Maybe/Some: (Any -> Maybe)
-(Maybe/Some) = λa λb (b Maybe/Some/tag a)
+Maybe_/Some: (Any -> Maybe_)
+(Maybe_/Some) = λa λb (b Maybe_/Some/tag a)
 
-Maybe/None/tag: _
-(Maybe/None/tag) = 1
+Maybe_/None/tag: _
+(Maybe_/None/tag) = 1
 
-Maybe/None: Maybe
-(Maybe/None) = λa (a Maybe/None/tag)
+Maybe_/None: Maybe_
+(Maybe_/None) = λa (a Maybe_/None/tag)


### PR DESCRIPTION
## Summary of Changes

The following updates have been made to `builtins.bend`:

### New/Updated Types and Functions

#### **1. `Maybe`**
- **New type definition:**
  ```bend
  type Maybe(T):
    Some {val: T}
    None
  ```

#### **2. `Map`**
- **Updated type definition:**
  ```bend
  type Map(T):
    Node {value: Maybe(T), ~left: Map(T), ~right: Map(T)}
    Leaf
  ```
  Now, every `Node` stores a `Maybe` type to explicitly represent the presence or absence of a value.

  ```
- **Updated/added functions:**
  - `Maybe/unwrap`: Retrieves the value inside Maybe/Some
  - `Map/set`: Inserts or updates a value in the map.
  - `Map/get`: Retrieves a value from the map, returning a `Maybe` type.
  - `Map/map`: Applies a function to each value in the map.
  - `Map/contains`: Checks whether a key exists in the map.
  - `Map/get_check`: Retrieves a value and performs additional validation.

---

## Why remove unreachable() from Map nodes?

   - You cannot see which elements are in the Map, nor can you perform a fold operation on the Map to, for example, return a list of values or map each value. Since the stored elements are not usable for anything, it is not possible to use this structure to determine whether a given element is present in the map or not.
   - The `unreachable()` function incorrectly ignores type check and can often cause bugs where the type isn't checked for an entire branch altogether.
   - When checking the results of a program, receiving `*` does not tell you whether you merely hit an unused node, or if another function called unreachable().

---

## Tests
  - Tests for the new functions have been added at Bend/tests/golden_tests/prelude

---

## Documentation update
Partially updates documentation adding a section for the Maybe type and new Map functions






